### PR TITLE
feature(pagination): add 'no match(es) found' to unmatched queries

### DIFF
--- a/client/js/components/Search.jsx
+++ b/client/js/components/Search.jsx
@@ -86,6 +86,10 @@ class Search extends React.Component {
 Search.propTypes = {
   search: PropTypes.func.isRequired,
 };
+Search.defaultProps = {
+  page: 1
+};
+
 Search.contextTypes = {
   router: PropTypes.object.isRequired
 };

--- a/client/js/components/SearchPage.jsx
+++ b/client/js/components/SearchPage.jsx
@@ -76,11 +76,11 @@ class SearchPage extends React.Component {
 }
 const mapStateToProps = state => ({
   recipes: state.recipes.allRecipes,
-  searchErrors: state.recipes.failure
+  searchErrors: state.recipes.failure,
 });
 SearchPage.propTypes = {
   recipes: PropTypes.arrayOf(PropTypes.shape()),
-  searchErrors: PropTypes.bool
+  searchErrors: PropTypes.bool,
 };
 SearchPage.defaultProps = {
   recipes: [],

--- a/client/js/reducers/allRecipes.js
+++ b/client/js/reducers/allRecipes.js
@@ -1,5 +1,5 @@
 import initialState from '../store/initialState';
-import { GET_ALL_RECIPES, GET_ALL_RECIPES_ERROR, SEARCH_RECIPES, SEARCH_RECIPES_ERROR, GET_PAGE_DETAILS } from '../actions/actionTypes';
+import { GET_ALL_RECIPES, GET_ALL_RECIPES_ERROR, SEARCH_RECIPES, SEARCH_RECIPES_ERROR } from '../actions/actionTypes';
 
 const allRecipes = (state = initialState.recipes, action) => {
   switch (action.type) {
@@ -13,12 +13,6 @@ const allRecipes = (state = initialState.recipes, action) => {
       return {
         ...state,
         failure: action.message
-      };
-    case GET_PAGE_DETAILS:
-      return {
-        ...state,
-        page: action.details,
-        failure: ''
       };
     case SEARCH_RECIPES:
       return {

--- a/server/src/controllers/userControl.js
+++ b/server/src/controllers/userControl.js
@@ -42,11 +42,7 @@ export default class User {
             password: Password
           }).then((newUser) => {
             const token = jwt.sign({
-              id: newUser.id,
-              firstname: newUser.firstname,
-              lastname: newUser.lastname,
-              email: newUser.email,
-              notify: newUser.notify
+              id: newUser.id
             }, secret, { expiresIn: 86400 });
             return res.status(201)
               .json({
@@ -91,11 +87,7 @@ export default class User {
           const result = helper.decrypt(password, foundUser.dataValues.password);
           if (result) {
             const token = jwt.sign({
-              id: foundUser.dataValues.id,
-              firstname: foundUser.dataValues.firstname,
-              lastname: foundUser.dataValues.lastname,
-              email: foundUser.dataValues.email,
-              notify: foundUser.dataValues.notify
+              id: foundUser.dataValues.id
             }, secret, { expiresIn: 86400 });
             res.status(200)
               .json({


### PR DESCRIPTION
#### What does this PR do?
Adds `no match(es) found` to unmatched search parameters
#### Description of Task to be completed?
 * Check if recipes array is empty
 * Add `no match found` if recipes array is empty

#### How should this be manually tested?
Have the app working by:
 * run the command `npm run server` on the command line to start the server
 * once app is running, navigate to the app using `localhost:5050`
 * click on the search bar
* Type in search queries/parameters

 #### Any background context you want to provide?
 Nil

### Pivotal tracker number
151342474
  
  
  